### PR TITLE
fixup mesh-gateways-l7 Prometheus config

### DIFF
--- a/mesh-gateways-l7/main.tf
+++ b/mesh-gateways-l7/main.tf
@@ -14,7 +14,7 @@ resource "random_string" "cluster_id" {
 locals {
    cluster_id = var.use_cluster_id ? "-${random_string.cluster_id.result}" : ""
 
-   agent_conf = file("${path.module}/consul-config/agent-conf.hcl")
+   agent_conf = templatefile("${path.module}/consul-config/agent-conf.hcl", {"prometheus_address": "prometheus${local.cluster_id}:9090"})
 }
 
 resource "docker_network" "consul_bridge_network" {

--- a/mesh-gateways-l7/primary.tf
+++ b/mesh-gateways-l7/primary.tf
@@ -59,11 +59,15 @@ module "primary_clients" {
             "api-v1.hcl" = file("${path.module}/consul-config/api-v1.hcl")
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "envoy-admin": {
                "internal": 19000,
                "external": 19003,
                "protocol": "tcp"
-            }
+            },
          }
       },
       {
@@ -74,6 +78,10 @@ module "primary_clients" {
             "web.hcl" = file("${path.module}/consul-config/web.hcl")
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "web-external": {
                "internal": 10000,
                "external": 10001,
@@ -99,6 +107,10 @@ module "primary_clients" {
             "agent-conf.hcl" = local.agent_conf
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "envoy-admin": {
                "internal": 19000,
                "external": 19001,
@@ -119,6 +131,10 @@ module "primary_clients" {
             "api-v2.hcl" = file("${path.module}/consul-config/api-v2.hcl")
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "envoy-admin": {
                "internal": 19000,
                "external": 19004,

--- a/mesh-gateways-l7/prometheus/prometheus.yml
+++ b/mesh-gateways-l7/prometheus/prometheus.yml
@@ -20,9 +20,10 @@ scrape_configs:
   static_configs:
   - targets:
     - consul-primary-ui${cluster_id}:8500
-    - consul-client${cluster_id}-primary-1:8500
-    - consul-client${cluster_id}-primary-2:8500
-    - consul-client${cluster_id}-primary-3:8500
+    - consul-primary-api-v1-manager${cluster_id}:8500
+    - consul-primary-web-manager${cluster_id}:8500
+    - consul-primary-gateway-manager${cluster_id}:8500
+    - consul-primary-api-v2-manager${cluster_id}:8500
     labels:
       dc: primary
       role: client
@@ -48,9 +49,9 @@ scrape_configs:
   static_configs:
   - targets:
     - consul-secondary-ui${cluster_id}:8500
-    - consul-client${cluster_id}-secondary-1:8500
-    - consul-client${cluster_id}-secondary-2:8500
-    - consul-client${cluster_id}-secondary-3:8500
+    - consul-secondary-api-v2-manager${cluster_id}:8500
+    - consul-secondary-web-manager${cluster_id}:8500
+    - consul-secondary-gateway-manager${cluster_id}:8500
     labels:
       dc: secondary
       role: client
@@ -60,7 +61,7 @@ scrape_configs:
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-primary-3:19000
+    - consul-primary-gateway-manager${cluster_id}:19000
     labels:
       dc: primary
       role: mesh-gateway
@@ -70,47 +71,58 @@ scrape_configs:
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-secondary-3:19000
+    - consul-secondary-gateway-manager${cluster_id}:19000
     labels:
       dc: secondary
       role: mesh-gateway
 
-- job_name: primary-socat-proxy
+- job_name: primary-api-proxy
   scrape_interval: 15s
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-primary-1:19000
+    - consul-primary-api-v1-manager${cluster_id}:19000
     labels:
       dc: primary
       role: sidecar
 
-- job_name: secondary-socat-proxy
+- job_name: secondary-api-proxy
   scrape_interval: 15s
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-secondary-1:19000
+    - consul-secondary-api-v2-manager${cluster_id}:19000
     labels:
       dc: secondary
       role: sidecar
 
-- job_name: primary-tcpproxy-proxy
+- job_name: primary-web-proxy
   scrape_interval: 15s
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-primary-2:19000
+    - consul-primary-web-manager${cluster_id}:19000
     labels:
       dc: primary
       role: sidecar
 
-- job_name: secondary-tcpproxy-proxy
+- job_name: secondary-web-proxy
   scrape_interval: 15s
   metrics_path: "/stats/prometheus"
   static_configs:
   - targets:
-    - consul-client${cluster_id}-secondary-2:19000
+    - consul-secondary-web-manager${cluster_id}:19000
     labels:
       dc: secondary
       role: sidecar
+
+- job_name: primary-api-proxy-v2
+  scrape_interval: 15s
+  metrics_path: "/stats/prometheus"
+  static_configs:
+  - targets:
+    - consul-primary-api-v2-manager${cluster_id}:19000
+    labels:
+      dc: primary
+      role: sidecar
+

--- a/mesh-gateways-l7/secondary.tf
+++ b/mesh-gateways-l7/secondary.tf
@@ -64,6 +64,10 @@ module "secondary_clients" {
             "api-v2.hcl" = file("${path.module}/consul-config/api-v2.hcl")
          }
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "envoy-admin": {
                "internal": 19000,
                "external": 19013,
@@ -79,6 +83,10 @@ module "secondary_clients" {
             "web.hcl" = file("${path.module}/consul-config/web.hcl")
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "web-external": {
                "internal": 10000,
                "external": 10002,
@@ -106,6 +114,10 @@ module "secondary_clients" {
             # "mg.hcl" = file("gateway.hcl")
          },
          "ports": {
+            "http": {
+               "internal": 8500,
+               "protocol": "tcp"
+            },
             "envoy-admin": {
                "internal": 19000,
                "external": 19011,


### PR DESCRIPTION
Not quite sure if `8500` is the appropriate port to be exposing or if `protocol` should be set to `http` instead of `tcp` anywhere, but this at least gets the existing Prometheus scrape targets pointed correctly and healthy (some might be missing though?)